### PR TITLE
[PKG-4126] 0.5.2 ❄️

### DIFF
--- a/recipe/abs.yaml
+++ b/recipe/abs.yaml
@@ -1,0 +1,3 @@
+upload_channels:
+  - sfe1ed40
+aggregate_branch: no312

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,10 +32,15 @@ test:
 
 about:
   home: https://github.com/liormizr/s3path
+  dev_url: https://github.com/liormizr/s3path
+  doc_url: https://github.com/liormizr/s3path/blob/master/README.rst
   license: Apache-2.0
   license_family: APACHE
   license_file: LICENSE
   summary: Pathlib Extension for AWS S3 Service, to provide File-System/Path like interface
+  description: |
+    S3Path provide a Python convenient File-System/Path like interface for AWS S3 Service 
+    using boto3 S3 resource as a driver.
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,6 +18,8 @@ requirements:
   host:
     - pip
     - python
+    - wheel
+    - setuptools
   run:
     - python
     - boto3 >=1.16.35

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,6 @@ requirements:
     - python
     - boto3 >=1.16.35
     - smart_open
-    - packaging
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,15 +11,15 @@ source:
 
 build:
   number: 0
-  noarch: python
+  skip: True  # [py<38]
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
     - pip
-    - python >=3.8
+    - python
   run:
-    - python >=3.8
+    - python
     - boto3 >=1.16.35
     - smart_open
     - packaging

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 0
   skip: True  # [py<38]
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,6 +29,10 @@ requirements:
 test:
   imports:
     - s3path
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/liormizr/s3path


### PR DESCRIPTION
s3path 0.5.2 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-4126](https://anaconda.atlassian.net/browse/PKG-4126) 
- [Upstream repository](https://github.com/liormizr/s3path/tree/0.5.2)
- [Upstream changelog/diff](https://github.com/liormizr/s3path/releases/tag/0.5.2)

### Explanation of changes:

- Minimal changes from conda-forge
- Tests require `mock_aws` from `moto >=5.0.0` which not available from defaults.


[PKG-4126]: https://anaconda.atlassian.net/browse/PKG-4126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ